### PR TITLE
Fix P2 PSP bin exporting, general program improvements

### DIFF
--- a/Formats/P2IS/PSP/BinToContainer.cs
+++ b/Formats/P2IS/PSP/BinToContainer.cs
@@ -25,7 +25,7 @@ namespace ClassicPersonaToolkit.Formats.P2IS.PSP
                 nodeList.Add(new NodeData(i, 0, size));
             }
 
-            long padding = 0;
+            long padding = dr.Stream.Position;
             while (dr.ReadInt32() == 0)
             {
                 padding = dr.Stream.Position;
@@ -35,7 +35,7 @@ namespace ClassicPersonaToolkit.Formats.P2IS.PSP
             {
                 node.Position += padding;
                 file.Root.Add(new Node($"{node.Id}", new BinaryFormat(source.Stream, node.Position, node.Size)));
-                padding += node.Size;
+                padding += ((node.Size + 0xF) >> 4) << 4;
             }
 
             return file;

--- a/Formats/P2IS/PSP/GzBinToContainer.cs
+++ b/Formats/P2IS/PSP/GzBinToContainer.cs
@@ -42,6 +42,7 @@ namespace ClassicPersonaToolkit.Formats.P2IS.PSP
 
                 nodeA.Size = nodeB.Position - nodeA.Position;
             }
+            nodeList.RemoveAt(nodeList.Count - 1);
 
             foreach (var node in nodeList)
             {

--- a/Helpers/P2IS/PSP/P2ISHelper.cs
+++ b/Helpers/P2IS/PSP/P2ISHelper.cs
@@ -19,6 +19,8 @@ namespace ClassicPersonaToolkit.Helpers.P2IS.PSP
                 var container = binNode.TransformWith<Formats.P2IS.PSP.BinToContainer>();
                 Console.Write("Write to directory: ");
                 string dir = Console.ReadLine();
+                if (!Path.EndsInDirectorySeparator(dir))
+                    dir += Path.DirectorySeparatorChar;
 
                 if (!Directory.Exists(dir + Path.GetFileNameWithoutExtension(filePath)))
                     Directory.CreateDirectory(dir + Path.GetFileNameWithoutExtension(filePath));
@@ -37,8 +39,7 @@ namespace ClassicPersonaToolkit.Helpers.P2IS.PSP
                     Console.WriteLine($"Writing {f.Name} in {dir + Path.GetFileNameWithoutExtension(filePath)}...");
                     f.Stream.WriteTo(dir + Path.GetFileNameWithoutExtension(filePath) + Path.DirectorySeparatorChar + f.Name + ".bin");
                 }
-                Console.Write("Finished writing! (Press Enter to continue)");
-                Console.ReadLine();
+                Console.WriteLine("Finished writing!");
             }
         }
 
@@ -49,6 +50,8 @@ namespace ClassicPersonaToolkit.Helpers.P2IS.PSP
                 var container = binNode.TransformWith<Formats.P2IS.PSP.GzBinToContainer>();
                 Console.Write("Write to directory: ");
                 string dir = Console.ReadLine();
+                if (!Path.EndsInDirectorySeparator(dir))
+                    dir += Path.DirectorySeparatorChar;
 
                 if (!Directory.Exists(dir + Path.GetFileNameWithoutExtension(filePath)))
                     Directory.CreateDirectory(dir + Path.GetFileNameWithoutExtension(filePath));
@@ -72,8 +75,7 @@ namespace ClassicPersonaToolkit.Helpers.P2IS.PSP
                         decStream.CopyTo(fileStream);
                     }
                 }
-                Console.Write("Finished writing! (Press Enter to continue)");
-                Console.ReadLine();
+                Console.WriteLine("Finished writing!");
             }
         }
     }

--- a/Program.cs
+++ b/Program.cs
@@ -144,6 +144,8 @@
 
                 if (option != '0')
                 {
+                    Console.Write("(Press Enter to continue)");
+                    Console.ReadLine();
                     ShowMenu();
                 }
             }


### PR DESCRIPTION
General:
Requires the user to press enter before returning to the menu, preventing error messages from disappearing instantly
Accounts for missing trailing slashes in output directories

P2 PSP Bin:
Initializes `padding` at the stream position, otherwise bins with no padding here won't be exported correctly
Rounds `padding` up to the next multiple of 0x10 while reading files, needed for some bins with oddly-sized files

P2 PSP GzBin:
Removes the last entry from `nodeList` after file sizes are calculated, since it doesn't correspond to an actual file